### PR TITLE
Change signit.signature module's interface

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,9 +65,9 @@ from psycopg2 import IntegrityError
 async def post(request):
     message = request.headers['Unix-Timestamp']
     signature = request.headers['Authorization']
-    access_key, hmac_digest = signit.signature.parse(signature)
+    prefix, access_key, hmac_digest = signit.signature.parse(signature)
     secret_key = await get_secret_key_from_db(access_key)
-    if not signit.signature.verify(access_key, secret_key, message, signature):
+    if not signit.signature.verify(hmac_digest, secret_key, message):
         raise web.HTTPUnauthorized('Invalid signature')
     try:
         await create_user(request)

--- a/docs/signature.md
+++ b/docs/signature.md
@@ -18,38 +18,37 @@ Creates a HMAC signature to pass to `Authorization` header or query string.
 - **access_key** (*str*) - A public access key that allows to identify the client
 - **secret_key** (*str*) - A private secret key to hash the message with
 - **message** (*str*) - A message to hash
-- **algorithm** - Is the digest name, digest constructor or module for the HMAC object to use (default ``hashlib.sha256``). For more details see [*``hmac.new``*](https://docs.python.org/3.5/library/hmac.html#hmac.new)
+- **algorithm** - Is the digest name, digest constructor or module for the HMAC object to use (default ``hashlib.sha256``). For more details see [*``hmac.new``*](https://docs.python.org/3.5/library/hmac.html#hmac.new). Used to create a HMAC.
+- **auth_header_prefix** (*str*) - A prefix for ``Authorization`` header (default ``'HMAC-SHA256'``).
 
-**Returns** (*str*) - a generated signature in format of `'<prefix> <access key>:<hmac signature>'`
+**Returns** (*str*) - a generated signature in format of `'<auth_header_prefix> <access_key>:<hmac_hex_digest>'`
 
 ---
 
-> **``signit.signature.parse(signature, auth_header_prefix=None)``**
+> **``signit.signature.parse(signature)``**
 
 Parses a signature created before with ``signit.signature.create``.
 
 **Parameters:**
 
-- **signature** (*str*) - a signature to parse
-- **auth_header_prefix** (*str*) - a header prefix you expect signature to have. If set, the ``ValueError`` will be raised if the ``signature`` has different prefix.
+- **signature** (*str*) - a signature to parse (the value from ``Authorization`` header).
 
-**Returns** (*tuple*) - ``(<access_key>, <hmac_signature>)`` tuple
+**Returns** (*list*) - Signagure's parts in form of ``[<auth_header_prefix>, <access_key>, <hmac_hex_digest>]``.
 
 ---
 
-> **``signit.signature.verify(access_key, secret_key, message, signature,
-           auth_header_prefix=AUTH_PREFIX_HEADER)``**
+> **``signit.signature.verify(hmac_hex_digest, secret_key, message, algorithm=sha256)``**
 
-Verifies the signature (e.g. provided by API client) against known ``access_key``, ``secret_key`` and ``message``. 
+Verifies the signature (e.g. provided by API client) against known ``secret_key`` and ``message``. 
 
-In other words it allows the server side to make sure the ``message`` has been hashed with an appropriate ``secret_key`` that belongs to the client identified by its ``access_key``.
+In other words it allows the server side to make sure the ``message`` has been hashed with an appropriate ``secret_key``.
 
 **Parameters:**
 
-- **access_key** (*str*) - A public access key that allows to identify the client
-- **secret_key** (*str*) - A private secret key to hash the message with
-- **message** (*str*) - A message to hash
-- **signature** (*str*) - A signature provided by client in format of ``'<prefix> <access key>:<hmac signature>'``
-- **auth_header_prefix** - a header prefix you're expect to see in provided ``signature`` to reproduce its (signature's) exact copy during the verification.
+- **hmac_hex_digest** (*str*) - A message's hash to check.
+Namely it's ``<hmac_hex_digest>`` part from the ``Authorization`` header's value (``'<auth_header_prefix> <access_key>:<hmac_hex_digest>'``).
+- **secret_key** (*str*) - A private secret key to hash the message with.
+- **message** (*str*) - A message to hash.
+- **algorithm** - Is the digest name, digest constructor or module for the HMAC object to use (default ``hashlib.sha256``). For more details see [*``hmac.new``*](https://docs.python.org/3.5/library/hmac.html#hmac.new). Used to create a HMAC.
 
-**Returns** (*bool*) - is the provided `signature` valid, namely is successfully verified against known on the server side access, secret key and the message.
+**Returns** (*bool*) - is the provided `hmac_hex_digest` valid, namely is successfully verified against known on the server side secret key and the message.

--- a/signit/_constants.py
+++ b/signit/_constants.py
@@ -3,5 +3,5 @@ import string
 AUTH_PREFIX_HEADER = 'HMAC-SHA256'
 KEY_CHARS = string.ascii_letters + string.digits
 KEY_LENGTH = 32
-SIGNATURE_FORMAT = '{prefix} {access_key}:{signature}'
+SIGNATURE_FORMAT = '{auth_header_prefix} {access_key}:{hmac_hex_digest}'
 UTF8 = 'utf-8'

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -23,13 +23,13 @@ def _message():
 
 
 @pytest.fixture(scope='module')
-def _signature():
+def _hmac_digest():
     return '0947c88ce16d078dde4a2aded1fe4627643a378757dccc3428c19569fea99542'
 
 
 @pytest.fixture(scope='module')
-def _full_signature(_prefix, _access_key, _signature):
-    return '{} {}:{}'.format(_prefix, _access_key, _signature)
+def _full_signature(_prefix, _access_key, _hmac_digest):
+    return '{} {}:{}'.format(_prefix, _access_key, _hmac_digest)
 
 
 def test_create(_access_key, _secret_key, _message, _full_signature):
@@ -38,21 +38,17 @@ def test_create(_access_key, _secret_key, _message, _full_signature):
     assert actual_result == expected_result, 'Should produce correct signature'
 
 
-def test_parse(_access_key, _signature, _full_signature):
-    access_key, signature = signit.signature.parse(_full_signature)
+def test_parse(_prefix, _access_key, _hmac_digest, _full_signature):
+    prefix, access_key, hmac_digest = signit.signature.parse(_full_signature)
     assert (
-        (access_key, signature) == (_access_key, _signature),
-        'Should parse access key and signature correctly'
+        (prefix, access_key, hmac_digest) == (_prefix, _access_key,
+                                              _hmac_digest),
+        'Should parse prefix, access key and hmac digest correctly'
     )
-    with pytest.raises(ValueError) as e:
-        signit.signature.parse(_full_signature,
-                               auth_header_prefix='WRONG_PREFIX')
-    assert 'Invalid prefix value in `Authorization` header.' in str(e.value)
 
 
-def test_verify(_access_key, _secret_key, _message, _full_signature):
-    valid = (_access_key, _secret_key, _message, _full_signature)
-    len_valid = len(valid)
+def test_verify(_hmac_digest, _secret_key, _message):
+    valid = (_hmac_digest, _secret_key, _message)
 
     def _invalid(wrong_index):
         args = list(valid)
@@ -60,7 +56,7 @@ def test_verify(_access_key, _secret_key, _message, _full_signature):
         args.insert(wrong_index, arg + 'x')
         return args
 
-    invalid = (_invalid(i) for i in range(len_valid - 1))
+    invalid = (_invalid(i) for i, val in enumerate(valid))
 
     assert signit.signature.verify(*valid)
 


### PR DESCRIPTION
Changed interface of `signit.signature.parse` and `signit.signature.verify`.
Updated documentation and examples.